### PR TITLE
Checking dispatch logic, reducing redundant checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ docs/build
 docs/source/_generated
 .coverage
 charlotte.log
+
+.mypy_cache
+.vscode
+_testing_snippets.py

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -12,7 +12,7 @@ class Dispatcher(object):
         database_connection: The datanase interface.
         consumer: The discord REST API consumer to send messages through.
     """
-    COMMAND_PREFIX = "!c/" # Must end with delimiter
+    COMMAND_PREFIX = "!c/"  # Must end with delimiter
     DELIMITER      = "/"
 
     def __init__(self, inc_queue, database_connection, consumer, commands, queue_timeout=10, logging=logging):
@@ -33,7 +33,7 @@ class Dispatcher(object):
         Returns:
             A boolean indicating whether the message is a command.
         """
-        return len(content) >= len(Dispatcher.COMMAND_PREFIX) and content[:3] == Dispatcher.COMMAND_PREFIX
+        return content[:len(Dispatcher.COMMAND_PREFIX)] == Dispatcher.COMMAND_PREFIX
 
     def parse(self, content):
         """Parses a message to extract the command and its parameters.
@@ -45,10 +45,9 @@ class Dispatcher(object):
             A tuple containing the command identifier and the parameters.
         """
         if self.is_command(content):
-
             # Extract command
             #commands look like:
-            # prefix(includes delimiter) command delimiter params
+            #   prefix(includes delimiter) command delimiter params
             # without spaces
             command = content.split(Dispatcher.DELIMITER)[1]
             if command == "":
@@ -63,6 +62,7 @@ class Dispatcher(object):
                 params = params[1:]
 
             return command, params
+
         return None, None
 
     def dispatch(self, command_id, message, *args):
@@ -76,7 +76,8 @@ class Dispatcher(object):
         Returns:
             The results of the command.
         """
-        self.logger.info("Command called by %s(%s): %s.", message.username, message.author_id, command_id)
+        self.logger.info("Command called by %s(%s): %s.",
+                         message.username, message.author_id, command_id)
         command = self.commands.identifiers[command_id]
         return command(message, self.data_conn, *args)
 
@@ -111,10 +112,6 @@ class Dispatcher(object):
                 message = self.inc_queue.get(timeout=self.queue_timeout)
             except queue.Empty:
                 continue
-
-            if message == None:
-                self.stop()
-                break
 
             self.process_message(message)
         self.logger.info("Dispatcher loop ended.")


### PR DESCRIPTION
# Code
1. Changed
    ```python
    return len(content) >= len(Dispatcher.COMMAND_PREFIX) and content[:3] == Dispatcher.COMMAND_PREFIX
    ```
    to
    ```python
    return content[:len(Dispatcher.COMMAND_PREFIX)] == Dispatcher.COMMAND_PREFIX
    ```
    Because:
    - It will reduce the number of checking required from 2 to 1
    - It will free the need to specify the length of the prefix everytime it's changed.
2. Commented
```python
if message == None:
    self.stop()
    break
```
After discussion, this is to prevent message being None when `timeout` was not an option for `queue.get()`.
With `timeout` message will never be None when the codes is reached - queue.Empty Exception will be raised if message is None, effectively continue the loop and ignore the codes.

# Formatting
Random formattings from autopep8